### PR TITLE
Ensure Contract.send() returns the this.provider.send() return value,…

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -9,7 +9,7 @@ var contract = (function(module) {
   }
 
   Provider.prototype.send = function() {
-    this.provider.send.apply(this.provider, arguments);
+    return this.provider.send.apply(this.provider, arguments);
   };
 
   Provider.prototype.sendAsync = function() {


### PR DESCRIPTION
… else event.stopWatching() breaks completely

Fixed a bug that's been there all the way since `ether-pudding` `3.2.0` (possibly earlier). This is a pain for us and we've been hacking the `ether-pudding` `classtemplate.js` file for ages to get around it while waiting for a fix.

Please accept this so we can move forward and leverage the contract `event.stopWatching()` mechanisms as intended.