### PR TITLE
[bugfix] fix `deployed()` 'auto-resolve' in console

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -397,7 +397,7 @@ var contract = (function(module) {
 
     deployed: function() {
       var self = this;
-      var val = {}; //this.at(this.address);
+      var val = this.at(this.address);
 
       // Add thennable to allow people to opt into new recommended usage.
       val.then = function(fn) {


### PR DESCRIPTION
In [the docs](http://truffleframework.com/docs/getting_started/console#features) it says that when using `truffle console`, you should be able to use contract methods as such:

```
MyContract.deployed().method.call()
```

However in the current version of truffle (3.1.1) this doesn't work; all of the methods on `deployed()` return `undefined`. 

It appears that un-commenting this line fixes that behaviour, although I'm not sure why it was commented out in the first place.
