### PR TITLE
Refactor `deployed()` to return a Promise

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -413,26 +413,19 @@ var contract = (function(module) {
 
     deployed: function() {
       var self = this;
-      var val = {}; //this.at(this.address);
+      return self.detectNetwork().then(function() {
+        // We don't have a network config for the one we found
+        if (self._json.networks[self.network_id] == null) {
+          throw new Error(self.contract_name + " has not been deployed to detected network (network/artifact mismatch)");
+        }
 
-      // Add thennable to allow people to opt into new recommended usage.
-      val.then = function(fn) {
-        return self.detectNetwork().then(function() {
-          // We don't have a network config for the one we found
-          if (self._json.networks[self.network_id] == null) {
-            throw new Error(self.contract_name + " has not been deployed to detected network (network/artifact mismatch)");
-          }
+        // If we found the network but it's not deployed
+        if (!self.isDeployed()) {
+          throw new Error(self.contract_name + " has not been deployed to detected network (" + self.network_id + ")");
+        }
 
-          // If we found the network but it's not deployed
-          if (!self.isDeployed()) {
-            throw new Error(self.contract_name + " has not been deployed to detected network (" + self.network_id + ")");
-          }
-
-          return new self(self.address);
-        }).then(fn);
-      };
-
-      return val;
+        return new self(self.address);
+      });
     },
 
     defaults: function(class_defaults) {


### PR DESCRIPTION
Currently `deployed` returns an object with a `then()` method. This makes it feel like a promise without actually being one. 

This breaks down when one expects to handle errors thrown from within the implementation of `deployed`. E.g:

```
const deployedContract = contract.deployed().catch(handleError);
// Doesn't work: `catch()` is not defined on returned object like on actual promises
```

Using async/await, it is not possible to catch thrown errors using try/catch from `deployed()`:

```
try {
  deployedContract = contract.deployed();
} catch(err) {
  handleErr(err);
}
// Doesn't work: error is thrown from the promise within the `then` method and doesn't
// propagate properly to this try/catch block.
```

Instead, the current workaround is:

```
try {
  deployedContract = contract.deployed().then();
} catch(err) {
  handleErr(err);
}
```

Which doesn't feel right. Since promises are used in 5 other instances within this package, it might make sense to make `deployed()` also return one. This is what this PR achieves.

PS: The edge-case I was trying to handle when I ran into this was a user browsing to my Dapp while on a network where my contract is not deployed.