### PR TITLE
Fix for missing topics arg in decodeEvent function

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -70,10 +70,10 @@ var contract = (function(module) {
 
         var argTopics = logABI.anonymous ? copy.topics : copy.topics.slice(1);
         var indexedData = "0x" + argTopics.map(function (topics) { return topics.slice(2); }).join("");
-        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData);
+        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData, log.topics);
 
         var notIndexedData = copy.data;
-        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData);
+        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData, log.topics);
 
         copy.event = logABI.name;
 


### PR DESCRIPTION
Since there is no testsuite and this 'hack' fixes my problem when decoding event from ERC20 contract, Approve event. Maybe someone should take a closer look