### PR TITLE
Pass in topics to ethJSABI to satisfy the `decodeEvent` interface

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -70,10 +70,10 @@ var contract = (function(module) {
 
         var argTopics = logABI.anonymous ? copy.topics : copy.topics.slice(1);
         var indexedData = "0x" + argTopics.map(function (topics) { return topics.slice(2); }).join("");
-        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData);
+        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData, copy.topics);
 
         var notIndexedData = copy.data;
-        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData);
+        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData, copy.topics);
 
         copy.event = logABI.name;
 


### PR DESCRIPTION
I ran into an issue where truffle-contract's call to `ethJSABI.decodeEvent` was throwing because it was expecting `topics` to be passed in as the third parameter. I've added the topics to the two calls to `decodeEvent`. 

Looks like this change to ethjs-abi was introduced in this [commit](https://github.com/ethjs/ethjs-abi/commit/a367dacf144804d0f6998868ac566af9eae26efd#diff-1fdf421c05c1140f6d71444ea2b27638L113).
