### PR TITLE
Bump web3 to 0.19 to avoid filterCreationErrorCallback issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ethjs-abi": "0.1.8",
     "truffle-blockchain-utils": "0.0.1",
     "truffle-contract-schema": "0.0.5",
-    "web3": "^0.18.0"
+    "web3": "^0.19.0"
   },
   "devDependencies": {
     "browserify": "^14.0.0",


### PR DESCRIPTION
Encountered "TypeError: filterCreationErrorCallback is not a function" when migrating. Culprit was truffle contract. Have to bump web3 to avoid it.