### PR TITLE
Document estimateGas method

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Run this function to estimate the gas usage:
 instance.setValue.estimateGas(5).then(function(result) {
   // result => estimated gas for this transaction
 });
+```
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ instance.send(web3.toWei(1, "ether")).then(function(result) {
 });
 ```
 
+#### Estimating gas usage
+
+Run this function to estimate the gas usage:
+
+```javascript
+instance.setValue.estimateGas(5).then(function(result) {
+  // result => estimated gas for this transaction
+});
+
 # Testing
 
 This package is the result of breaking up EtherPudding into multiple modules. Tests currently reside within [truffle-artifactor](https://github.com/trufflesuite/truffle-artifactor) but will soon move here.


### PR DESCRIPTION
I had to do this, because a transaction run out of gas. After estimating it I saw that the estimation was way higher than [the provided gas limit](https://kovan.etherscan.io/tx/0xb360f99991215f66a64f9a72515f099a00ce4174b31f9da60e8bd2466b3162ec). I.e. estimated gas: 2849004, used gas: 940000. I wonder why truffle does not estimate gas before sending transactions.