### PR TITLE
Allows calls to overloaded solidity functions

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -273,16 +273,25 @@ var contract = (function(module) {
     for (var i = 0; i < this.abi.length; i++) {
       var item = this.abi[i];
       if (item.type == "function") {
-        if (item.constant == true) {
-          this[item.name] = Utils.promisifyFunction(contract[item.name], constructor);
-        } else {
-          this[item.name] = Utils.synchronizeFunction(contract[item.name], this, constructor);
-        }
 
-        this[item.name].call = Utils.promisifyFunction(contract[item.name].call, constructor);
-        this[item.name].sendTransaction = Utils.promisifyFunction(contract[item.name].sendTransaction, constructor);
-        this[item.name].request = contract[item.name].request;
-        this[item.name].estimateGas = Utils.promisifyFunction(contract[item.name].estimateGas, constructor);
+        var wrapFunction = function(isConstant, web3Func) {
+          var wrapped = isConstant ? Utils.promisifyFunction(web3Func, constructor) :
+            Utils.synchronizeFunction(web3Func, this, constructor);
+          wrapped.call = Utils.promisifyFunction(web3Func.call, constructor);
+          wrapped.sendTransaction = Utils.promisifyFunction(web3Func.sendTransaction, constructor);
+          wrapped.request = web3Func.request;
+          wrapped.estimateGas = Utils.promisifyFunction(web3Func.estimateGas, constructor);
+
+          return wrapped;
+        };
+
+        if (!this[item.name]) {
+          this[item.name] = wrapFunction(item.constant, contract[item.name]);
+        }
+        if (item.inputs.length > 0) {
+          var argsString = item.inputs.reduce(function(concat, curr) { return concat + "," + curr["type"]}, "").substring(1);
+          this[item.name][argsString] = wrapFunction(item.constant, contract[item.name][argsString]);
+        }
       }
 
       if (item.type == "event") {

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -28,6 +28,18 @@ contract Example {
   function triggerEvent() {
     ExampleEvent(msg.sender, 8);
   }
+  
+  function setValueOverload(uint val) {
+    value = val;
+  }
+  
+  function setValueOverload(uint part1, uint part2) {
+    value = part1 + part2;
+  }
+  
+  function setValueOverload(uint part1, uint part2, uint part3) {
+    value = part1 + part2 + part3;
+  }
 
   function() payable {
     fallbackTriggered = true;

--- a/test/abstractions.js
+++ b/test/abstractions.js
@@ -91,6 +91,33 @@ describe("Abstractions", function() {
       assert.equal(value.valueOf(), 5, "Ending value should be five");
     }).then(done).catch(done);
   });
+  
+  it("should call overloaded methods", function(done) {
+    var example;
+    Example.new({gas: 3141592}).then(function(instance) {
+      example = instance;
+      return example.setValueOverload["uint256,uint256"](5, 5);
+    }).then(function(tx) {
+      return example.value.call();      
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 10, "Sum value should be 10");
+      return example.setValueOverload["uint256"](7);      
+    }).then(function(tx) {
+      return example.value.call();
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 7, "Single value should be 7");
+      return example.setValueOverload["uint256,uint256,uint256"](3,3,5);
+    }).then(function(tx) {
+      return example.value.call();
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 11, "Triple sum value should be 11");
+      return example.setValueOverload(3);
+    }).then(function(tx) {
+      return example.value.call();
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 3, "Default overload value should be 3");
+    }).then(done).catch(done);
+  });
 
   it("shouldn't synchronize constant functions", function(done) {
     var example;


### PR DESCRIPTION
Fixes wrapping overloaded Solidity functions. They are exposed in the same way `web3` is exposing overloaded functions. Examples for `transfer` ERC223 overload

```
await token.transfer["address,uint256,bytes"](
      address,
      initialBalance,
      data,
      { from: fromAddr }
    );
```
ERC20
```
await token.transfer["address,uint256"](
      address,
      initialBalance,
      { from: fromAddr }
    );
```
or
```
await token.transfer(
      address,
      initialBalance,
      { from: fromAddr }
    );
```
Please note that default overload is a result of order of function in ABI. first encountered function will be the default. this is a wrong approach as it can for example change when ABI generator changes order. I'm not fixing this for backward compatibility.

Test case was provided.

This fixes following issue raised in `truffle` repo: 
https://github.com/trufflesuite/truffle/issues/569