### PR TITLE
[WIP] Add defaultBlock param for calls

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -117,10 +117,9 @@ var contract = (function(module) {
 
         // It's only tx_params if it's an object and not a BigNumber.
         // It's only defaultBlock if there's an extra non-object input that's not tx_params.
-        var hasInputs = inputs !== undefined;
         var hasTxParams = Utils.is_object(last_arg) && !Utils.is_big_number(last_arg);
-        var hasDefaultBlock = hasInputs && !hasTxParams && args.length > inputs.length;
-        var hasDefaultBlockWithParams = hasInputs && hasTxParams && args.length - 1 > inputs.length;
+        var hasDefaultBlock = !hasTxParams && args.length > inputs.length;
+        var hasDefaultBlockWithParams = hasTxParams && args.length - 1 > inputs.length;
 
         // Detect and extract defaultBlock parameter
         if (hasDefaultBlock || hasDefaultBlockWithParams) {
@@ -297,7 +296,7 @@ var contract = (function(module) {
           this[item.name] = Utils.synchronizeFunction(contract[item.name], this, constructor);
         }
 
-        this[item.name].call = Utils.promisifyFunction(contract[item.name].call, constructor);
+        this[item.name].call = Utils.promisifyFunction(contract[item.name].call, constructor, item.inputs);
         this[item.name].sendTransaction = Utils.promisifyFunction(contract[item.name].sendTransaction, constructor);
         this[item.name].request = contract[item.name].request;
         this[item.name].estimateGas = Utils.promisifyFunction(contract[item.name].estimateGas, constructor);

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -21,6 +21,10 @@ contract Example {
     return value;
   }
 
+  function getValuePlus(uint sum) constant returns(uint) {
+    return value + sum;
+  }
+
   function parrot(uint val) returns(uint) {
     return val;
   }

--- a/test/abstractions.js
+++ b/test/abstractions.js
@@ -123,6 +123,34 @@ describe("Abstractions", function() {
     }).then(done).catch(done);
   });
 
+  it.skip("should allow setting the defaultBlock parameter", function(done){
+    var example;
+    var initialBlock;
+    var nextBlock;
+    var initialValue = web3.toBigNumber(5);
+
+    Example.new(initialValue, {gas: 3141592}).then(function(instance) {
+      example = instance;
+      return new Promise(function(accept, reject){
+        web3.eth.getBlockNumber(function(err, val){
+          (err) ? reject(err) : accept(val);
+        })
+      });
+    }).then(function(blockNumber) {
+      initialBlock = blockNumber;
+      return example.setValue(10, {gas: 3141592});
+    }).then(function(tx){
+      nextBlock = tx.receipt.blockNumber;
+      return example.getValue(initialBlock);
+    }).then(function(defaultBlockValue){
+      assert.notEqual(initialBlock, nextBlock, "blockNumbers should differ");
+      assert(initialValue.eq(defaultBlockValue), "should get initial value");
+      return example.getValuePlus(10, initialBlock);
+    }).then(function(defaultBlockValue){
+      assert.equal(initialValue.plus(10).eq(defaultBlockValue), "should get inital value + 10");
+    }).then(done).catch(done);
+  })
+
   it("should return transaction hash, logs and receipt when using synchronised transactions", function(done) {
     var example = null;
     Example.new({gas: 3141592}).then(function(instance) {


### PR DESCRIPTION
Adds ability to include a defaultBlock parameter for `.calls`, allowing you to query past chain state using methods. Resolves [truffle-artifactor 34](https://github.com/trufflesuite/truffle-artifactor/issues/34).

Includes a test, currently skipped. 

WIP - `ganache` doesn't support this [(yet)](https://github.com/trufflesuite/ganache-cli/issues/385).  