### PR TITLE
Validate number of constructor arguments

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -365,6 +365,15 @@ var contract = (function(module) {
             tx_params = args.pop();
           }
 
+          // Validate constructor args
+          var constructor = self.abi.filter(function(item){
+            return item.type === 'constructor';
+          });
+
+          if (constructor.length && constructor[0].inputs.length !== args.length){
+            throw new Error(self.contractName + " contract constructor expected " + constructor[0].inputs.length + " arguments, received " + args.length);
+          }
+
           tx_params = Utils.merge(self.class_defaults, tx_params);
 
           if (tx_params.data == null) {

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -4,12 +4,7 @@ contract Example {
   event ExampleEvent(address indexed _from, uint num);
 
   function Example(uint val) {
-    if (val == 0x0) {
-      value = 1;
-    } else {
-      value = val;
-    }
-
+    value = val;
     fallbackTriggered = false;
   }
 

--- a/test/abstractions.js
+++ b/test/abstractions.js
@@ -72,14 +72,14 @@ describe("Abstractions", function() {
   });
 
   it("should set the transaction hash of contract instantiation", function() {
-    return Example.new({gas: 3141592}).then(function(example) {
+    return Example.new(1, {gas: 3141592}).then(function(example) {
       assert(example.transactionHash, "transactionHash should be non-empty");
     });
   });
 
   it("should get and set values via methods and get values via .call", function(done) {
     var example;
-    Example.new({gas: 3141592}).then(function(instance) {
+    Example.new(1, {gas: 3141592}).then(function(instance) {
       example = instance;
       return example.value.call();
     }).then(function(value) {
@@ -125,7 +125,7 @@ describe("Abstractions", function() {
 
   it("should return transaction hash, logs and receipt when using synchronised transactions", function(done) {
     var example = null;
-    Example.new({gas: 3141592}).then(function(instance) {
+    Example.new(1, {gas: 3141592}).then(function(instance) {
       example = instance;
       return example.triggerEvent();
     }).then(function(result) {
@@ -146,7 +146,7 @@ describe("Abstractions", function() {
 
   it("should trigger the fallback function when calling sendTransaction()", function() {
     var example = null;
-    return Example.new({gas: 3141592}).then(function(instance) {
+    return Example.new(1, {gas: 3141592}).then(function(instance) {
       example = instance;
       return example.fallbackTriggered();
     }).then(function(triggered) {
@@ -168,7 +168,7 @@ describe("Abstractions", function() {
 
   it("should trigger the fallback function when calling send() (shorthand notation)", function() {
     var example = null;
-    return Example.new({gas: 3141592}).then(function(instance) {
+    return Example.new(1, {gas: 3141592}).then(function(instance) {
       example = instance;
       return example.fallbackTriggered();
     }).then(function(triggered) {
@@ -196,6 +196,14 @@ describe("Abstractions", function() {
     done();
   });
 
+  it("errors when creating a contract with invalid constructor params", function(){
+    return Example.new(25, 25, {gas: 3141592}).then(function(){
+      assert.fail();
+    }).catch(function(error){
+      assert(error.message.search("constructor") >= 0, "new() should have thrown");
+    });
+  });
+
   it("creates a network object when an address is set if no network specified", function(done) {
     var NewExample = contract({
       abi: abi,
@@ -209,7 +217,7 @@ describe("Abstractions", function() {
 
     assert.equal(NewExample.network_id, null);
 
-    NewExample.new({gas: 3141592}).then(function(instance) {
+    NewExample.new(1, {gas: 3141592}).then(function(instance) {
       // We have a network id in this case, with new(), since it was detected,
       // but no further configuration.
       assert.equal(NewExample.network_id, network_id);

--- a/test/networks.js
+++ b/test/networks.js
@@ -96,9 +96,9 @@ describe("Different networks:", function() {
 
   // Most tests rely on this. It was a test; now it's a before step.
   before("can deploy to different networks", function(done) {
-    ExampleOne.new({gas: 3141592}).then(function(example) {
+    ExampleOne.new(1, {gas: 3141592}).then(function(example) {
       ExampleOne.address = example.address;
-      return ExampleTwo.new({gas: 3141592});
+      return ExampleTwo.new(1, {gas: 3141592});
     }).then(function(example) {
       ExampleTwo.address = example.address;
     }).then(function() {
@@ -251,7 +251,7 @@ describe("Different networks:", function() {
     assert.isNotNull(Example.toJSON().networks[network_two_id].address);
     assert.equal(Example.network_id, null);
 
-    Example.new({from: ExampleTwo.defaults().from, gas: 3141592}).then(function(instance) {
+    Example.new(1, {from: ExampleTwo.defaults().from, gas: 3141592}).then(function(instance) {
       assert.deepEqual(instance.abi, Example.abi);
     }).then(done).catch(done);
   });
@@ -275,7 +275,7 @@ describe("Different networks:", function() {
     var from = ExampleTwo.defaults().from;
     var example;
 
-    return ExampleSetup.new({from: from, gas: 3141592}).then(function(instance) {
+    return ExampleSetup.new(1, {from: from, gas: 3141592}).then(function(instance) {
       example = ExampleDetect.at(instance.address);
 
       assert.equal(ExampleDetect.network_id, null);
@@ -302,7 +302,7 @@ describe("Different networks:", function() {
     var from = ExampleTwo.defaults().from;
     var example;
 
-    return ExampleSetup.new({from: from, gas: 3141592}).then(function(instance) {
+    return ExampleSetup.new(1, {from: from, gas: 3141592}).then(function(instance) {
       example = ExampleDetect.at(instance.address);
 
       assert.equal(ExampleDetect.network_id, null);
@@ -403,7 +403,7 @@ describe("Different networks:", function() {
       // we've mined two more blocks. We'll use ExampleTwo for this
       // that's hooked up to the same network.
       times(2, function(n, finished) {
-        ExampleTwo.new({gas: 3141592}).then(function() {
+        ExampleTwo.new(1, {gas: 3141592}).then(function() {
           finished();
         }).catch(finished);
       }, function(err) {


### PR DESCRIPTION
Addresses #82 by length checking constructor arguments, adds a test and updates the test suite to reflect new strictness. 

It's possible some people are relying on the constructor being agnostic about arguments to set defaults, the way `truffle-contracts` own tests do.  On the other hand both `web3 1.0` and `solc` run validations like this so it seems like default behavior across the stack.