### PR TITLE
Fix synchronization timeout

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -158,7 +158,7 @@ var contract = (function(module) {
                 return;
               }
 
-              var timeout = C.synchronization_timeout || 240000;
+              var timeout = (C.synchronization_timeout === 0) ? 0 : 240000;
               var start = new Date().getTime();
 
               var make_attempt = function() {

--- a/contract.js
+++ b/contract.js
@@ -158,7 +158,13 @@ var contract = (function(module) {
                 return;
               }
 
-              var timeout = (C.synchronization_timeout === 0) ? 0 : 240000;
+              var timeout;
+              if (C.synchronization_timeout === 0 || C.synchronization_timeout !== undefined) {
+                timeout = C.synchronization_timeout;
+              } else {
+                timeout = 240000;
+              }
+
               var start = new Date().getTime();
 
               var make_attempt = function() {


### PR DESCRIPTION
Addresses 
+ [truffle 750](https://github.com/trufflesuite/truffle/issues/594), 
+ [truffle 718](https://github.com/trufflesuite/truffle/issues/718),
+ [truffle 594](https://github.com/trufflesuite/truffle/issues/594),

In truffle-migrate [resolverintercept.js](https://github.com/trufflesuite/truffle-migrate/blob/develop/resolverintercept.js#L18-L21) it looks like the intent is to let migrations take as long as they take:
```javascript
// During migrations, we could be on a network that takes a long time to accept
// transactions (i.e., contract deployment close to block size). Because successful
// migration is more important than wait time in those cases, we'll synchronize "forever".
resolved.synchronization_timeout = 0;
```
but the timeout in `synchronizeFunction` in truffle-contract is accidentally always set to `240000`.