### PR TITLE
Reject on status 0x00

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -1,6 +1,7 @@
 var ethJSABI = require("ethjs-abi");
 var BlockchainUtils = require("truffle-blockchain-utils");
 var Web3 = require("web3");
+var StatusError = require("./statuserror.js")
 
 // For browserified version. If browserify gave us an empty version,
 // look for the one provided by the user.
@@ -175,10 +176,8 @@ var contract = (function(module) {
                   // Handles "0x00" or hex 0
                   if (receipt != null) {
                     if (parseInt(receipt.status, 16) == 0){
-                      return reject({
-                        tx: tx,
-                        receipt: receipt
-                      })
+                      var statusError = new StatusError(tx_params, tx, receipt);
+                      return reject(statusError);
                     } else {
                       return accept({
                         tx: tx,

--- a/contract.js
+++ b/contract.js
@@ -172,8 +172,9 @@ var contract = (function(module) {
                   if (err) return reject(err);
 
                   // Reject on transaction failures, accept otherwise
+                  // Handles "0x00" or hex 0
                   if (receipt != null) {
-                    if (receipt.status === "0x00"){
+                    if (parseInt(receipt.status, 16) == 0){
                       return reject({
                         tx: tx,
                         receipt: receipt

--- a/contract.js
+++ b/contract.js
@@ -171,12 +171,20 @@ var contract = (function(module) {
                 C.web3.eth.getTransactionReceipt(tx, function(err, receipt) {
                   if (err) return reject(err);
 
+                  // Reject on transaction failures, accept otherwise
                   if (receipt != null) {
-                    return accept({
-                      tx: tx,
-                      receipt: receipt,
-                      logs: Utils.decodeLogs(C, instance, receipt.logs)
-                    });
+                    if (receipt.status === "0x00"){
+                      return reject({
+                        tx: tx,
+                        receipt: receipt
+                      })
+                    } else {
+                      return accept({
+                        tx: tx,
+                        receipt: receipt,
+                        logs: Utils.decodeLogs(C, instance, receipt.logs)
+                      });
+                    }
                   }
 
                   if (timeout > 0 && new Date().getTime() - start > timeout) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
+    "debug": "DEBUG=ganache-core mocha",
     "compile": "browserify ./index.js -i web3 -o ./dist/truffle-contract.js && uglifyjs ./dist/truffle-contract.js -o ./dist/truffle-contract.min.js"
   },
   "repository": {
@@ -33,6 +34,7 @@
     "async": "^2.3.0",
     "browserify": "^14.0.0",
     "chai": "^3.5.0",
+    "debug": "^3.1.0",
     "ganache-core": "2.1.0-beta.0",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "^2.3.0",
     "browserify": "^14.0.0",
     "chai": "^3.5.0",
-    "ganache-core": "0.0.1",
+    "ganache-core": "2.1.0-beta.0",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "require-nocache": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ethjs-abi": "0.1.8",
     "truffle-blockchain-utils": "^0.0.3",
     "truffle-contract-schema": "^1.0.0",
+    "truffle-error": "0.0.2",
     "web3": "^0.20.1"
   },
   "devDependencies": {

--- a/statuserror.js
+++ b/statuserror.js
@@ -12,14 +12,15 @@ function StatusError(args, tx, receipt) {
 
   if(receipt.gasUsed === gasLimit){
 
-    message = "Transaction: " + tx + " exited with an error (status 0 - invalid opcode).\n" +
+    message = "Transaction: " + tx + " exited with an error (status 0) after consuming all gas.\n" +
       "Please check that the transaction:\n" +
       "    - satisfies all conditions set by Solidity `assert` statements.\n" +
-      "    - has enough gas to execute all internal Solidity function calls.\n";
+      "    - has enough gas to execute the full transaction.\n" +
+      "    - does not trigger an invalid opcode by other means (ex: accessing an array out of bounds).";
 
   } else {
 
-    message = "Transaction: " + tx + " exited with an error (status 0 - revert).\n" +
+    message = "Transaction: " + tx + " exited with an error (status 0).\n" +
       "Please check that the transaction:\n" +
       "    - satisfies all conditions set by Solidity `require` statements.\n" +
       "    - does not trigger a Solidity `revert` statement.\n";

--- a/statuserror.js
+++ b/statuserror.js
@@ -1,0 +1,32 @@
+var TruffleError = require("truffle-error");
+var inherits = require("util").inherits;
+var defaultGas = 90000;
+var web3 = require("web3");
+
+inherits(StatusError, TruffleError);
+
+function StatusError(args, tx, receipt) {
+  var message;
+  var gasLimit = parseInt(args.gas) || defaultGas;
+
+  if(receipt.gasUsed === gasLimit){
+
+    message = "Transaction: " + tx + " exited with an error (status 0 - invalid opcode).\n" +
+      "Please check that the transaction:\n" +
+      "    - satisfies all conditions set by Solidity `assert` statements.\n" +
+      "    - has enough gas to execute all internal Solidity function calls.\n";
+
+  } else {
+
+    message = "Transaction: " + tx + " exited with an error (status 0 - revert).\n" +
+      "Please check that the transaction:\n" +
+      "    - satisfies all conditions set by Solidity `require` statements.\n" +
+      "    - does not trigger a Solidity `revert` statement.\n";
+  }
+
+  StatusError.super_.call(this, message);
+  this.tx = tx;
+  this.receipt = receipt;
+}
+
+module.exports = StatusError;

--- a/statuserror.js
+++ b/statuserror.js
@@ -1,9 +1,10 @@
 var TruffleError = require("truffle-error");
 var inherits = require("util").inherits;
-var defaultGas = 90000;
 var web3 = require("web3");
 
 inherits(StatusError, TruffleError);
+
+var defaultGas = 90000;
 
 function StatusError(args, tx, receipt) {
   var message;

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -24,6 +24,10 @@ contract Example {
     ExampleEvent(msg.sender, 8);
   }
 
+  function triggerError() {
+    require(false);
+  }
+
   function() payable {
     fallbackTriggered = true;
   }

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -1,5 +1,6 @@
 contract Example {
   uint public value;
+  uint public counter;
   bool public fallbackTriggered;
   event ExampleEvent(address indexed _from, uint num);
 
@@ -24,8 +25,22 @@ contract Example {
     ExampleEvent(msg.sender, 8);
   }
 
-  function triggerError() {
+  function triggerRequireError() {
     require(false);
+  }
+
+  function triggerAssertError() {
+    assert(false);
+  }
+
+  function runsOutOfGas() {
+    consumesGas();
+  }
+
+  function consumesGas() {
+    for(uint i = 0; i < 10000; i++){
+      counter = i;
+    }
   }
 
   function() payable {

--- a/test/abstractions.js
+++ b/test/abstractions.js
@@ -254,7 +254,7 @@ describe("Abstractions", function() {
       }).then(function(){
         assert.fail();
       }).catch(function(e){
-        assert(e.receipt.status === '0x00')
+        assert(parseInt(e.receipt.status, 16) == 0)
         done();
       });
     });

--- a/test/cloning.js
+++ b/test/cloning.js
@@ -9,13 +9,14 @@ process.removeListener("uncaughtException", process.listeners("uncaughtException
 
 var fs = require("fs");
 var requireNoCache = require("require-nocache")(module);
+var debug = require("debug")("ganache-core");
 var TestRPC = require("ganache-core");
 var contract = require("../");
 var async = require("async");
 var Schema = require("truffle-contract-schema");
 
 var log = {
-  log: function(){}
+  log: debug
 };
 
 describe("Cloning", function() {

--- a/test/cloning.js
+++ b/test/cloning.js
@@ -14,7 +14,9 @@ var contract = require("../");
 var async = require("async");
 var Schema = require("truffle-contract-schema");
 
-
+var log = {
+  log: function(){}
+};
 
 describe("Cloning", function() {
   var network_one_id;
@@ -32,8 +34,8 @@ describe("Cloning", function() {
 
     network_one_id = 1000;
     network_two_id = 1001;
-    network_one = TestRPC.provider({network_id: network_one_id, seed: network_one_id});
-    network_two = TestRPC.provider({network_id: network_two_id, seed: network_two_id});
+    network_one = TestRPC.provider({network_id: network_one_id, seed: network_one_id, logger: log});
+    network_two = TestRPC.provider({network_id: network_two_id, seed: network_two_id, logger: log});
 
     ExampleOne = contract(compiled);
     ExampleTwo = ExampleOne.clone();

--- a/test/linking.js
+++ b/test/linking.js
@@ -13,9 +13,13 @@ var Schema = require("truffle-contract-schema");
 // which happens to be the first.
 process.removeListener("uncaughtException", process.listeners("uncaughtException")[0] || function() {});
 
+var log = {
+  log: function(){}
+};
+
 describe("Library linking", function() {
   var LibraryExample;
-  var provider = TestRPC.provider();
+  var provider = TestRPC.provider({logger:log});
   var network_id;
   var web3 = new Web3();
   web3.setProvider(provider)
@@ -77,7 +81,7 @@ describe("Library linking with contract objects", function() {
   var exampleConsumer;
   var accounts;
   var web3;
-  var provider = TestRPC.provider();
+  var provider = TestRPC.provider({logger: log});
   var web3 = new Web3();
   web3.setProvider(provider)
 

--- a/test/linking.js
+++ b/test/linking.js
@@ -5,6 +5,7 @@ var path = require("path");
 var requireNoCache = require("require-nocache")(module);
 var contract = require("../");
 var Web3 = require("web3");
+var debug = require("debug")("ganache-core");
 var TestRPC = require("ganache-core");
 var fs = require("fs");
 var solc = require("solc");
@@ -14,7 +15,7 @@ var Schema = require("truffle-contract-schema");
 process.removeListener("uncaughtException", process.listeners("uncaughtException")[0] || function() {});
 
 var log = {
-  log: function(){}
+  log: debug
 };
 
 describe("Library linking", function() {

--- a/test/networks.js
+++ b/test/networks.js
@@ -16,6 +16,10 @@ var contract = require("../");
 var Web3 = require("web3");
 var times = require("async/times");
 
+var log = {
+  log: function(){}
+}
+
 function getNetworkId(provider, callback) {
   var web3 = new Web3();
   web3.setProvider(provider);
@@ -65,8 +69,8 @@ describe("Different networks:", function() {
     // Setup
     network_one_id = 1000;
     network_two_id = 1001;
-    network_one = TestRPC.provider({network_id: network_one_id, seed: network_one_id});
-    network_two = TestRPC.provider({network_id: network_two_id, seed: network_two_id});
+    network_one = TestRPC.provider({network_id: network_one_id, seed: network_one_id, logger: log});
+    network_two = TestRPC.provider({network_id: network_two_id, seed: network_two_id, logger: log});
 
     network_one.__marker = "one";
     network_two.__marker = "two";

--- a/test/networks.js
+++ b/test/networks.js
@@ -10,6 +10,7 @@ process.removeListener("uncaughtException", process.listeners("uncaughtException
 
 var fs = require("fs");
 var requireNoCache = require("require-nocache")(module);
+var debug = require("debug")("ganache-core");
 var TestRPC = require("ganache-core");
 var BlockchainUtils = require("truffle-blockchain-utils");
 var contract = require("../");
@@ -17,7 +18,7 @@ var Web3 = require("web3");
 var times = require("async/times");
 
 var log = {
-  log: function(){}
+  log: debug
 }
 
 function getNetworkId(provider, callback) {

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,39 @@
+var ganache = require("ganache-core");
+var Web3 = require("web3");
+
+var log = {
+  log: function(){}
+}
+
+var util = {
+
+  // Spins up ganache with arbitrary options and
+  // binds web3 & a contract instance to it.
+  setUpProvider: function(instance, options){
+    options = options || {};
+    Object.assign(options, {logger: log})
+
+    return new Promise(function(accept, reject){
+      var provider = ganache.provider(options);
+      var web3 = new Web3();
+
+      web3.setProvider(provider);
+      instance.setProvider(provider);
+
+      web3.eth.getAccounts(function(err, accs) {
+        if (err) reject(err);
+
+        instance.defaults({
+          from: accs[0]
+        });
+
+        accept({
+          web3: web3,
+          accounts: accs
+        });
+      });
+    })
+  },
+}
+
+module.exports = util;

--- a/test/util.js
+++ b/test/util.js
@@ -1,8 +1,9 @@
+var debug = require("debug")("ganache-core");
 var ganache = require("ganache-core");
 var Web3 = require("web3");
 
 var log = {
-  log: function(){}
+  log: debug
 }
 
 var util = {


### PR DESCRIPTION
Addresses requirement that truffle-contract behave appropriately with clients who only signal transaction error via the tx receipt by setting it's status property to 0x0.

+ Updates ganache dev dep to latest: `2.1.0-beta.0` (which can be configured to omit an error from the response, like Geth/Parity)
+ Adds logic to reject with the tx hash, receipt object, error message if status is 0x0
+ Adds logic to interpret meaning of status (revert, invalid opcode, OOG on internal calls).
+ Adds tests for both client behaviors.
+ Extracts provider setup into a utility to make passing options to ganache a little cleaner in `abstractions.js`


If web3 errors we reject with the message, if status is bad, we reject with the usual transaction response, minus any log data.

Also explicitly configuring ganache to run silently in the tests because it's logging everything out to the console.  

[EDITED}