### PR TITLE
Allow web3-style overloaded functions

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -276,19 +276,30 @@ var contract = (function(module) {
     this.contract = contract;
 
     // Provision our functions.
+    this.methods = {};
     for (var i = 0; i < this.abi.length; i++) {
       var item = this.abi[i];
       if (item.type == "function") {
-        if (item.constant == true) {
-          this[item.name] = Utils.promisifyFunction(contract[item.name], constructor);
-        } else {
-          this[item.name] = Utils.synchronizeFunction(contract[item.name], this, constructor);
-        }
+        var wrapFunction = function(isConstant, web3Func) {
+          var wrapped = isConstant ? Utils.promisifyFunction(web3Func, constructor) :
+            Utils.synchronizeFunction(web3Func, this, constructor);
+          wrapped.call = Utils.promisifyFunction(web3Func.call, constructor);
+          wrapped.sendTransaction = Utils.promisifyFunction(web3Func.sendTransaction, constructor);
+          wrapped.request = web3Func.request;
+          wrapped.estimateGas = Utils.promisifyFunction(web3Func.estimateGas, constructor);
 
-        this[item.name].call = Utils.promisifyFunction(contract[item.name].call, constructor);
-        this[item.name].sendTransaction = Utils.promisifyFunction(contract[item.name].sendTransaction, constructor);
-        this[item.name].request = contract[item.name].request;
-        this[item.name].estimateGas = Utils.promisifyFunction(contract[item.name].estimateGas, constructor);
+          return wrapped;
+        };
+
+        if (!this[item.name]) {
+          this[item.name] = wrapFunction(item.constant, contract[item.name]);
+        }
+        if (item.inputs.length > 0) {
+          var argsString = item.inputs.reduce(function(concat, curr) { return concat + "," + curr["type"]}, "").substring(1);
+          this.methods[item.name + '(' + argsString + ')'] = wrapFunction(item.constant, contract[item.name][argsString]);
+        } else {
+          this.methods[item.name + '()'] = wrapFunction(item.constant, contract[item.name]['']);
+        }
       }
 
       if (item.type == "event") {

--- a/test/Example.sol
+++ b/test/Example.sol
@@ -24,6 +24,18 @@ contract Example {
     ExampleEvent(msg.sender, 8);
   }
 
+  function send() {
+    if (value > 0) {
+        value--;
+    }
+  }
+
+  function send(uint _value) {
+    if (value >= _value) {
+        value-= _value;
+    }
+  }
+
   function() payable {
     fallbackTriggered = true;
   }

--- a/test/abstractions.js
+++ b/test/abstractions.js
@@ -88,7 +88,17 @@ describe("Abstractions", function() {
     }).then(function(tx) {
       return example.value.call();
     }).then(function(value) {
-      assert.equal(value.valueOf(), 5, "Ending value should be five");
+      assert.equal(value.valueOf(), 5, "Value should be five");
+      return example.methods['send()']();
+    }).then(function(tx) {
+      return example.value.call();
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 4, "Value should be four");
+      return example.methods['send(uint256)'](2);
+    }).then(function(tx) {
+      return example.value.call();
+    }).then(function(value) {
+      assert.equal(value.valueOf(), 2, "Value should be two");
     }).then(done).catch(done);
   });
 


### PR DESCRIPTION
#75 proposed a way of accessing overloaded Solidity functions but it fails if there is a contract function called `send()` or another name used within truffle's contract object (`sendTransaction`, `allEvents`, etc).

This patch tweaks the changes made in #75 to use the web3-style overloads.  For example if a contract has the following methods:

```
function send() {...}
function send(uint256 amount) {...}
```

then they can be accessed from the contract instance with `contract.methods['send()']` and `contract.methods['send(uint256)']` respectively.  Examples can also be see in the tests in this PR.