### PR TITLE
Handle Geth `unknown transaction` error gracefully

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -170,7 +170,9 @@ var contract = (function(module) {
 
               var make_attempt = function() {
                 C.web3.eth.getTransactionReceipt(tx, function(err, receipt) {
-                  if (err) return reject(err);
+                  if (err && !err.toString().includes('unknown transaction')){
+                    return reject(err);
+                  }
 
                   // Reject on transaction failures, accept otherwise
                   // Handles "0x00" or hex 0


### PR DESCRIPTION
`geth 1.8` (which looks [spectacular](https://blog.ethereum.org/2018/02/14/geth-1-8-iceberg%C2%B9/)) has slightly different error handling. Querying the node for a receipt while the transaction is pending now returns an `unknown transaction` error. Previously, the call succeeded but the receipt was undefined. 

This PR adds logic to ignore the new error and continue polling. Manually tested by running MetaCoin migrations against `geth --dev --dev.period 1`

Should resolve [truffle 721](https://github.com/trufflesuite/truffle/issues/721). A little more on this topic at web3 [here](https://github.com/ethereum/web3.js/issues/1255#issuecomment-357876919)