### PR TITLE
Allow null transaction hashes

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -781,9 +781,6 @@ var contract = (function(module) {
         return transactionHash;
       },
       set: function(val) {
-        if(val === null) {
-          throw new Error("Could not set \`" + val + "\` as the transaction hash for " + this.contractName);
-        }
         this.network.transactionHash = val;
       }
     },


### PR DESCRIPTION
Addresses [truffle 836](https://github.com/trufflesuite/truffle/issues/836). This error is getting triggered when migrations use the `{overwrite: false}` option. 

It should be okay if the artifact doesn't have a record of the tx hash - we don't currently consume it.