### PR TITLE
Always define a defaultBlock value for .call

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -92,7 +92,7 @@ var execute = {
 
     return function() {
       var params = {};
-      var defaultBlock;
+      var defaultBlock = 'latest';
       var args = Array.prototype.slice.call(arguments);
       var lastArg = args[args.length - 1];
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,7 @@ set -o errexit
 
 run_geth() {
   docker run \
+    -v /$PWD/scripts:/scripts \
     -d \
     -p 8546:8546 \
     -p 30303:30303 \
@@ -16,6 +17,7 @@ run_geth() {
     --dev \
     --dev.period 2 \
     --targetgaslimit '7000000' \
+    js ./scripts/geth-accounts.js \
     > /dev/null &
 }
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -74,6 +74,12 @@ describe("Methods", function() {
       assert.equal(expectedValuePlus, retrievedValuePlus, "should get inital value + 10");
     });
 
+    it('should honor tx params when called', async function(){
+      const example = await Example.new(5);
+      const sender = await example.viewSender({from: accounts[2]});
+      assert.equal(sender, accounts[2]);
+    });
+
     it('should estimate gas', async function(){
       const example = await Example.new(5);
       const estimate = await example.setValue.estimateGas(25);
@@ -84,7 +90,7 @@ describe("Methods", function() {
 
     it("should return hash, logs and receipt when using synchronised transactions", async function() {
       const example = await Example.new(1);
-      const result = await example.triggerEvent();
+      const result = await example.triggerEvent({from: accounts[2]});
       const log = result.logs[0];
 
       assert.isDefined(result.tx, "transaction hash wasn't returned");
@@ -94,7 +100,7 @@ describe("Methods", function() {
       assert.equal(result.tx, result.receipt.transactionHash, "Tx had different hash than receipt");
       assert.equal(result.logs.length, 1, "logs array expected to be 1");
       assert.equal("ExampleEvent", log.event);
-      assert.equal(accounts[0], log.args._from);
+      assert.equal(accounts[2], log.args._from);
       assert.equal(8, log.args.num); // 8 is a magic number inside Example.sol
     });
 

--- a/test/sources/Example.sol
+++ b/test/sources/Example.sol
@@ -30,6 +30,10 @@ contract Example {
     return address(this);
   }
 
+  function viewSender() view returns(address){
+    return msg.sender;
+  }
+
   function getValue() constant returns(uint) {
     return value;
   }


### PR DESCRIPTION
Addresses [truffle 999](https://github.com/trufflesuite/truffle/issues/999). 

Passing `defaultBlock` as undefined into a `method.call` is causing `web3` to inadvertently discard tx params for calls. Setting it to 'latest' (the [default value](https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter)) resolves this. 

@RobertoC27 wrote some nice reproduction tests for this [here](https://gist.github.com/RobertoC27/63cbdf3ac598d84da9bcbb8d80f09629) - have added one of those cases as a regression test, and modified a `send` test to verify that `msg.sender` equals the tx param `from` field for `send` transactions as well. 